### PR TITLE
Bump up the osgi api version and maven bundle plugin version 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,13 +8,13 @@
 		<bundle.namespace>org.cytoscape.cyndex2</bundle.namespace>
 
 		<maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
-		<maven-bundle-plugin.version>3.4.0</maven-bundle-plugin.version>
+		<maven-bundle-plugin.version>4.1.0</maven-bundle-plugin.version>
 
 		<junit.version>4.12</junit.version>
 		<jetty.version>9.3.9.v20160517</jetty.version>
 		<jxbrowser.version>6.23.1</jxbrowser.version>
 		<cytoscape.api.version>3.7.0</cytoscape.api.version>
-		<osgi.api.version>4.2.0</osgi.api.version>
+		<osgi.api.version>6.0.0</osgi.api.version>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
@@ -193,7 +193,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.osgi</groupId>
-			<artifactId>org.osgi.compendium</artifactId>
+			<artifactId>osgi.cmpn</artifactId>
 			<version>${osgi.api.version}</version>
 			<scope>provided</scope>
 		</dependency>


### PR DESCRIPTION
This will fix runtime errors when set build target to Java 11.