### PR TITLE
Fix unlisted network visibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,21 +23,5 @@ jobs:
         distribution: 'temurin'
         cache: 'maven'
 
-    - name: Allow HTTP Maven repositories
-      run: |
-        mkdir -p ~/.m2
-        cat > ~/.m2/settings.xml << 'EOF'
-        <settings>
-          <mirrors>
-            <mirror>
-              <id>maven-default-http-blocker</id>
-              <mirrorOf>dummy</mirrorOf>
-              <name>Dummy mirror</name>
-              <url>http://0.0.0.0/</url>
-            </mirror>
-          </mirrors>
-        </settings>
-        EOF
-
     - name: Run tests
       run: xvfb-run mvn test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,29 +20,6 @@ jobs:
         distribution: 'temurin'
         cache: 'maven'
 
-    - name: Configure Maven settings
-      run: |
-        mkdir -p ~/.m2
-        cat > ~/.m2/settings.xml << 'EOF'
-        <settings>
-          <servers>
-            <server>
-              <id>cytoscape_releases</id>
-              <username>${env.REPO_USER}</username>
-              <password>${env.REPO_PWD}</password>
-            </server>
-          </servers>
-          <mirrors>
-            <mirror>
-              <id>maven-default-http-blocker</id>
-              <mirrorOf>dummy</mirrorOf>
-              <name>Dummy mirror</name>
-              <url>http://0.0.0.0/</url>
-            </mirror>
-          </mirrors>
-        </settings>
-        EOF
-
     - name: Extract and validate version from tag
       id: version
       run: |

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+--settings=.mvn/settings.xml

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,0 +1,17 @@
+<settings>
+  <servers>
+    <server>
+      <id>cytoscape_releases</id>
+      <username>${env.REPO_USER}</username>
+      <password>${env.REPO_PWD}</password>
+    </server>
+  </servers>
+  <mirrors>
+    <mirror>
+      <id>maven-default-http-blocker</id>
+      <mirrorOf>dummy</mirrorOf>
+      <name>Dummy mirror</name>
+      <url>http://0.0.0.0/</url>
+    </mirror>
+  </mirrors>
+</settings>

--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@
 		<dependency>
 			<groupId>org.ndexbio.client</groupId>
 			<artifactId>ndex-java-client</artifactId>
-			<version>2.5.2</version>
+			<version>3.0.0</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
 	<groupId>org.cytoscape</groupId>
 	<artifactId>cy-ndex-2</artifactId>
-	<version>3.7.2</version>
+	<version>3.7.3</version>
 	<packaging>bundle</packaging>
 	<name>CyNDEx-2</name>
 


### PR DESCRIPTION
Per bug report in #78 , this updates the ndex object model so the ndex client can parse the UNLISTED network visibilities.

Veriifed, can see UNLISTED shown:


<img width="1290" height="751" alt="Screenshot 2026-07-02 at 4 57 37 PM" src="https://github.com/user-attachments/assets/730b2120-793c-452f-8e01-c853c8ba3c69" />


